### PR TITLE
Harden workflow token scope and gate slash-command trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ on:
       - 'docs/**'
 
 permissions:
-  issues: write
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       issue-number: ${{ steps.vars.outputs.issue-number }}
@@ -51,6 +51,10 @@ jobs:
   test:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     needs: [build]
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -120,6 +124,9 @@ jobs:
   package:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [test]
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -7,8 +7,7 @@ jobs:
     if: |
       github.event.issue.pull_request
       && (
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-        || contains(fromJson(vars.SLASH_COMMAND_USER_ALLOWLIST || '[]'), github.event.comment.user.login)
+        contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -4,6 +4,12 @@ on:
     types: [created]
 jobs:
   slashCommandDispatch:
+    if: |
+      github.event.issue.pull_request
+      && (
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        || contains(fromJson(vars.SLASH_COMMAND_USER_ALLOWLIST || '[]'), github.event.comment.user.login)
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch


### PR DESCRIPTION
## Summary
- reduce top-level workflow permissions in CI to `contents: read`
- grant write scopes only to jobs that require them (`test`, `package`)
- add maintainer/allowlist gate to `issue_comment` slash-command dispatch workflow

## Security impact
This limits the blast radius for PR-triggered jobs and ensures command-triggered automation can only be started by trusted actors.

## Validation
- YAML parse validation for updated workflow files (`Psych.safe_load`)
- note: `actionlint` is not available in this environment
